### PR TITLE
fix intellisense

### DIFF
--- a/src/Server/Server.fsproj
+++ b/src/Server/Server.fsproj
@@ -17,7 +17,7 @@
     <EmbeddedResource Include="**\*.resx" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-060000">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Pin specific FSharp.NET.Sdk package version

because 1.0.0 is not yet supported by VSCode/Ionide/FSAC

The version range used was `1.0.0-beta-*` but anyway nuget resolved `1.0.0` instead of `1.0.0-beta-060000`