### PR TITLE
Reproduce docker root folder issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM microsoft/dotnet:1.1.0-sdk-msbuild-rc4
-COPY /deploy /app
-WORKDIR /app
+COPY /deploy .
 EXPOSE 8085
 ENTRYPOINT ["dotnet", "Server.dll"]


### PR DESCRIPTION
Run the follwoing to see the error:

   build.cmd CreateDockerImage
   docker run -it -p 8085:8085  --rm forki/fable-suave

![image](https://cloud.githubusercontent.com/assets/57396/23173391/4e550392-f859-11e6-8b71-c0518122f53e.png)

Note: If you revert the Dockerfile to

    FROM microsoft/dotnet:1.1.0-sdk-msbuild-rc4
    COPY /deploy /app
    WORKDIR /app
    EXPOSE 8085
    ENTRYPOINT ["dotnet", "Server.dll"] 

then everything works as expected