### PR TITLE
offload side-effects into commands

### DIFF
--- a/src/Client/Messages.fs
+++ b/src/Client/Messages.fs
@@ -5,6 +5,8 @@ open ServerCode.Domain
 
 type AppMsg = 
 | LoggedIn
+| LoggedOut
+| StorageFailure of exn
 | OpenLogIn
 | LoginMsg of LoginMsg
 | WishListMsg of WishListMsg


### PR DESCRIPTION
Side effects with explicit failure modes are offloaded into commands.

Arguably, logging into console is also a side-effect, but normally you'd have a piece of model dedicated to conveying the problems to the user, so instead of logging into console this would just update the model.