### PR TITLE
Don't rename chromedriver on macOS if it already exists

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -222,7 +222,7 @@ Target "BuildTests" (fun _ ->
 Target "RenameDrivers" (fun _ ->
     if not isWindows then
         run npmTool "install phantomjs" ""
-    if isMacOS then
+    if isMacOS && not <| File.Exists "test/UITests/bin/Release/chromedriver" then
         Fake.FileHelper.Rename "test/UITests/bin/Release/chromedriver" "test/UITests/bin/Release/chromedriver_macOS"
     elif isLinux then
         Fake.FileHelper.Rename "test/UITests/bin/Release/chromedriver" "test/UITests/bin/Release/chromedriver_linux64"    


### PR DESCRIPTION
This might be relevant for Linux as well, but I don't have access to a Linux installation of Mono and hence cannot test, so my changes only affect macOS. Fixes #62.