### PR TITLE
Fixes client build issues

### DIFF
--- a/src/Client/App.fs
+++ b/src/Client/App.fs
@@ -155,7 +155,7 @@ let viewPage model dispatch =
 let view model dispatch =
   div []
     [ lazyView2 Menu.view model.Menu dispatch
-      hr [] []
+      hr []
       div [ centerStyle "column" ] (viewPage model dispatch)
     ]
 

--- a/src/Client/pages/Login.fs
+++ b/src/Client/pages/Login.fs
@@ -115,7 +115,7 @@ let view model (dispatch: AppMsg -> unit) =
                     Placeholder "Username"
                     DefaultValue (U2.Case1 model.Login.UserName)
                     OnChange (fun ev -> dispatch (LoginMsg (SetUserName !!ev.target?value)))
-                    AutoFocus true ] []
+                    AutoFocus true ]
           ]
 
           div [ ClassName "input-group input-group-lg" ] [
@@ -129,7 +129,7 @@ let view model (dispatch: AppMsg -> unit) =
                         Placeholder "Password"
                         DefaultValue (U2.Case1 model.Login.Password)
                         OnChange (fun ev -> dispatch (LoginMsg (SetPassword !!ev.target?value)))
-                        onEnter (LoginMsg ClickLogIn) dispatch  ] []
+                        onEnter (LoginMsg ClickLogIn) dispatch  ]
             ]    
            
           div [ ClassName "text-center" ] [

--- a/src/Client/pages/WishList.fs
+++ b/src/Client/pages/WishList.fs
@@ -116,7 +116,7 @@ let newBookForm (model:Model) dispatch =
                                      ClassName "form-control"
                                      Placeholder "Please insert book title"
                                      Required true
-                                     OnChange (fun (ev:React.FormEvent) -> dispatch (WishListMsg (WishListMsg.TitleChanged !!ev.target?value))) ] []
+                                     OnChange (fun (ev:React.FormEvent) -> dispatch (WishListMsg (WishListMsg.TitleChanged !!ev.target?value))) ]
                              match model.TitleErrorText with
                              | Some e -> yield span [ClassName "glyphicon glyphicon-remove form-control-feedback"] []
                              | _ -> ()
@@ -135,7 +135,7 @@ let newBookForm (model:Model) dispatch =
                                      ClassName "form-control"
                                      Placeholder "Please insert authors"
                                      Required true
-                                     OnChange (fun (ev:React.FormEvent) -> dispatch (WishListMsg (WishListMsg.AuthorsChanged !!ev.target?value)))] []
+                                     OnChange (fun (ev:React.FormEvent) -> dispatch (WishListMsg (WishListMsg.AuthorsChanged !!ev.target?value)))]
                              match model.AuthorsErrorText with
                              | Some e -> yield span [ClassName "glyphicon glyphicon-remove form-control-feedback"] []
                              | _ -> ()
@@ -154,7 +154,7 @@ let newBookForm (model:Model) dispatch =
                                     ClassName "form-control"
                                     Placeholder "Please insert link"
                                     Required true
-                                    OnChange (fun (ev:React.FormEvent) -> dispatch (WishListMsg (WishListMsg.LinkChanged !!ev.target?value)))] []
+                                    OnChange (fun (ev:React.FormEvent) -> dispatch (WishListMsg (WishListMsg.LinkChanged !!ev.target?value)))]
                              match model.LinkErrorText with
                              | Some e -> yield span [ClassName "glyphicon glyphicon-remove form-control-feedback"] []
                              | _ -> ()


### PR DESCRIPTION
Several HTML elements were getting passed extra empty lists that were causing the client project to fail building.

** Someone else may already be addressing this, but I fixed it for my local development and thought it might be helpful if someone isn't working on it.  I can create an issue for this if that's more appropriate.**