### PR TITLE
Fix #98: Add InstallServer build target

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -90,8 +90,11 @@ Target "InstallDotNetCore" (fun _ ->
 // --------------------------------------------------------------------------------------
 // Build library & test project
 
-Target "BuildServer" (fun _ ->
+Target "InstallServer" (fun _ ->
     runDotnet serverPath "restore"
+)
+
+Target "BuildServer" (fun _ ->
     runDotnet serverPath "build"
 )
 
@@ -252,6 +255,7 @@ Target "All" DoNothing
 
 "Clean"
   ==> "InstallDotNetCore"
+  ==> "InstallServer"
   ==> "InstallClient"
   ==> "BuildServer"
   ==> "BuildClient"


### PR DESCRIPTION
After a change I did to the FAKE script, the `Run` target wasn't running `dotnet restore` on the Server project.