### PR TITLE
netcoreapp1.1 projects depend on 1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1.0-sdk-msbuild-rc4
+FROM microsoft/dotnet:1.1.1-sdk-1.0.1
 COPY /deploy /app
 WORKDIR /app
 EXPOSE 8085


### PR DESCRIPTION
The current base docker image does not include version 1.1.1 of the .NET Core Runtime, which is required by netcoreapp1.1 by default. [apparently](http://stackoverflow.com/questions/42726198/dotnet-build-to-specific-framework-version).

Without this change you will receive the following error when trying to run the docker container:

```
The specified framework 'Microsoft.NETCore.App', version '1.1.1' was not found.
  - Check application dependencies and target a framework version installed at:
      /usr/share/dotnet/shared/Microsoft.NETCore.App
  - The following versions are installed:
      1.1.0
      1.0.3
  - Alternatively, install the framework version '1.1.1'.
```

After updating the base image the app runs successfully.

I'm not sure if this change is appropriate, or if targeting a lower version of the framework explicitly is intended.