### PR TITLE
add gcp deploy example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM microsoft/dotnet:1.1.1-sdk-1.0.1
+FROM microsoft/dotnet:1.1.2-sdk
 COPY /deploy /app
 WORKDIR /app
+EXPOSE 8080
 EXPOSE 8085
 ENTRYPOINT ["dotnet", "Server.dll"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ If you are in [development mode](#development-mode) then you can use Expecto's f
 
 [Paket](https://fsprojects.github.io/Paket/) is a dependency manager and allows easier management of the NuGet packages.
 
+## Deployment alternatives
+
+### Google Cloud AppEngine
+
+The repository comes with a sample `app.yaml` file which is used to deploy to Google Cloud AppEngine using the custom flex environment. At the moment it seems like the application must run on port `8080` and that is set as a environment variable in the `app.yaml` file. When you run the deploy command it will first look for the `app.yaml` file and then look for the `Dockerfile` for what should deploy. The container that is deploy is exactly that same as the one that should have been deployed to Azure, but it is only set up to deploy from local to Google Cloud at the moment, and not from CI server to Google Cloud.
+
+Before you can execute the deploy command you also need to build the solution with the `Publish` target, that is so the container image will get the compiled binaries when the container build is executed via the deploy command.
+
+To execute the deploy you need a Google Cloud account and project configured as well as the tooling installed, https://cloud.google.com/sdk/downloads. The command you need to run is:
+
+    gcloud app deploy -q <--version=main> <--verbosity=debug>
+
+The `version` and `verbosity` flag isn't need, but it is recommended to use the `version` flag so you don't up with to many versions of your application without removing previous ones. Use `verbosity=debug` if you are having some problems.
+
+Deploy to the flex environment with a custom runtime like this is might take some time, but the instructions here should work.
+
 ## Maintainer(s)
 
 - [@forki](https://github.com/forki)

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,7 @@
+service: suave-fable
+runtime: custom
+env: flex
+health_check:
+  enable_health_check: False
+env_variables:
+  SUAVE_FABLE_PORT: '8080'

--- a/build.fsx
+++ b/build.fsx
@@ -209,7 +209,7 @@ Target "PrepareRelease" (fun _ ->
     if result <> 0 then failwith "Docker tag failed"
 )
 
-Target "CreateDockerImage" (fun _ ->
+Target "Publish" (fun _ ->
     let result =
         ExecProcess (fun info ->
             info.FileName <- dotnetExePath
@@ -229,7 +229,9 @@ Target "CreateDockerImage" (fun _ ->
     !! "src/Images/**/*.*" |> CopyFiles imageDir
 
     "src/Client/index.html" |> CopyFile clientDir
+)
 
+Target "CreateDockerImage" (fun _ ->
     let result =
         ExecProcess (fun info ->
             info.FileName <- "docker"
@@ -267,6 +269,7 @@ Target "All" DoNothing
   ==> "RenameDrivers"
   ==> "RunTests"
   ==> "All"
+  ==> "Publish"
   ==> "CreateDockerImage"
   ==> "PrepareRelease"
   ==> "Deploy"

--- a/src/Client/webpack.config.js
+++ b/src/Client/webpack.config.js
@@ -11,6 +11,7 @@ var babelOptions = {
 }
 
 var isProduction = process.argv.indexOf("-p") >= 0;
+var port = process.env.SUAVE_FABLE_PORT || "8085";
 console.log("Bundling for " + (isProduction ? "production" : "development") + "...");
 
 module.exports = {
@@ -24,7 +25,7 @@ module.exports = {
   devServer: {
     proxy: {
       '/api/*': {
-        target: 'http://localhost:8085',
+        target: 'http://localhost:' + port,
         changeOrigin: true
       }
     }

--- a/src/Server/Program.fs
+++ b/src/Server/Program.fs
@@ -2,6 +2,16 @@
 
 open System.IO
 
+let GetEnvVar var = 
+    match System.Environment.GetEnvironmentVariable(var) with
+    | null -> None
+    | value -> Some value
+
+let getPortsOrDefault defaultVal = 
+    match System.Environment.GetEnvironmentVariable("SUAVE_FABLE_PORT") with
+    | null -> defaultVal
+    | value -> value |> uint16
+
 [<EntryPoint>]
 let main args =
     try
@@ -13,7 +23,7 @@ let main args =
                 if Directory.Exists devPath then devPath else
                 @"./client"
 
-        Server.startServer (Path.GetFullPath clientPath)
+        Server.startServer (Path.GetFullPath clientPath) (getPortsOrDefault 8085us)
         0
     with
     | exn ->

--- a/src/Server/Server.fs
+++ b/src/Server/Server.fs
@@ -8,7 +8,7 @@ open Suave.Filters
 open Suave.Operators
 open Suave.RequestErrors
 
-let startServer clientPath =
+let startServer clientPath port =
     if not (Directory.Exists clientPath) then
         failwithf "Client-HomePath '%s' doesn't exist." clientPath
 
@@ -20,12 +20,11 @@ let startServer clientPath =
     //     failwithf "Out-HomePath '%s' is empty." outPath
 
     let logger = Logging.Targets.create Logging.Info [| "Suave" |]
-
     let serverConfig =
         { defaultConfig with
             logger = Targets.create LogLevel.Debug [|"ServerCode"; "Server" |]
             homeFolder = Some clientPath
-            bindings = [ HttpBinding.create HTTP (IPAddress.Parse "0.0.0.0") 8085us] }
+            bindings = [ HttpBinding.create HTTP (IPAddress.Parse "0.0.0.0") port] }
 
     let app =
         choose [


### PR DESCRIPTION
This PR contains:

* Update to Dockerfile, 1.1.1 --> 1.1.2 (needs to be verified on Azure)
* Update to `Readme` on how to deploy to GCP
* Update to app and test to allow for different port based on env variable
* Configuration file that is used to deploy to GCP 