### PR TITLE
Isolate user login test from changes in wish list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ AppPackages/
 # VSCode
 .vscode/
 
+# Vim
+*.swp
+
 # Others
 sql/
 *.Cache

--- a/test/UITests/Tests.fs
+++ b/test/UITests/Tests.fs
@@ -19,15 +19,20 @@ let tests =
             url serverUrl
             waitForElement ".elmish-app"
 
-            let logout = someElement  ".logout"
-            if logout.IsSome then click "Logout"
+            let logoutLinkSelector = ".logout"
+            let loginLinkSelector = "Login"
 
-            click "Login"
+            let logout = someElement logoutLinkSelector 
+            if logout.IsSome then
+                click logoutLinkSelector 
+                waitForElement loginLinkSelector
+
+            click loginLinkSelector
 
             "#username" << "test"
             "#password" << "test"
 
             click "Log In"
             
-            waitForElement "Isaac Abraham"
+            waitForElement logoutLinkSelector
     ]


### PR DESCRIPTION
As per commit, *If you remove Isaac's book from the wish list, the Canopy user login test fails, because it checks for Isaac.  While I agree that removing Isaac is a crime, the test should probably check for the logout option in the menu.  Changed to do this.*