### PR TITLE
WIP: Explore client code structure

### DIFF
--- a/src/Client/App.fs
+++ b/src/Client/App.fs
@@ -10,6 +10,7 @@ open Elmish.React
 open Fable.Import.Browser
 open Fable.PowerPack
 open Elmish.Browser.Navigation
+open Client.Model
 open Client.Messages
 open Elmish.Browser.UrlParser
 
@@ -49,7 +50,7 @@ let urlUpdate (result:Page option) model =
             let m,cmd = WishList.init user
             { model with Page = page; SubModel = WishListModel m }, Cmd.map WishListMsg cmd
         | None ->
-            model, Cmd.ofMsg Logout
+            model, Cmd.ofMsg LogOut
 
     | Some (Home as page) ->
         { model with Page = page; Menu = { model.Menu with query = "" } }, []
@@ -66,7 +67,7 @@ let init result =
 
 let update msg model =
     match msg, model.SubModel with
-    | AppMsg.OpenLogIn, _ ->
+    | Msg.OpenLogIn, _ ->
         let m,cmd = Login.init None
         { model with
             Page = Page.Login
@@ -105,24 +106,28 @@ let update msg model =
 
     | WishListMsg msg, _ -> model, Cmd.none
 
-    | AppMsg.LoggedIn, _ ->
+    // Log out can come from App or Menu.
+    | MenuMsg Menu.Msg.LogOut, _
+    | Msg.LogOut, _ ->
+        model, Cmd.ofFunc Utils.delete "user" (fun _ -> LoggedOut) StorageFailure
+
+    | Msg.LoggedIn, _ ->
         let nextPage = Page.WishList
         let m,cmd = urlUpdate (Some nextPage) model
         match m.Menu.User with
         | Some user ->
             m, Cmd.batch [cmd; Navigation.modifyUrl (toHash nextPage) ]
         | None ->
-            m, Cmd.ofMsg Logout
+            m, Cmd.ofMsg LogOut
 
-    | AppMsg.LoggedOut, _ ->
+
+    | Msg.LoggedOut, _ ->
         { model with
             Page = Page.Home
             SubModel = NoSubModel
             Menu = { model.Menu with User = None } },
         Navigation.modifyUrl (toHash Page.Home)
 
-    | AppMsg.Logout, _ ->
-        model, Cmd.ofFunc Utils.delete "user" (fun _ -> LoggedOut) StorageFailure
 
 // VIEW
 
@@ -140,19 +145,19 @@ let viewPage model dispatch =
     | Page.Login ->
         match model.SubModel with
         | LoginModel m ->
-            [ div [ ] [ Login.view m dispatch ]]
+            [ div [ ] [ Login.view m (LoginMsg >> dispatch) ]]
         | _ -> [ ]
 
     | Page.WishList ->
         match model.SubModel with
         | WishListModel m ->
-            [ div [ ] [ lazyView2 WishList.view m dispatch ]]
+            [ div [ ] [ lazyView2 WishList.view m (WishListMsg >> dispatch) ]]
         | _ -> [ ]
 
 /// Constructs the view for the application given the model.
 let view model dispatch =
   div []
-    [ lazyView2 Menu.view model.Menu dispatch
+    [ lazyView2 Menu.view model.Menu (MenuMsg >> dispatch)
       hr []
       div [ centerStyle "column" ] (viewPage model dispatch)
     ]

--- a/src/Client/Client.fsproj
+++ b/src/Client/Client.fsproj
@@ -4,12 +4,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../Server/Shared/Domain.fs" />
-    <Compile Include="Messages.fs" />
+    <Compile Include="Model.fs" />
     <Compile Include="Style.fs" />
     <Compile Include="Utils.fs" />
-    <Compile Include="pages/Menu.fs" />
+    <Compile Include="components/Menu.fs" />
     <Compile Include="pages/WishList.fs" />
     <Compile Include="pages/Login.fs" />
+    <Compile Include="Messages.fs" />
     <Compile Include="App.fs" />
     <DotNetCliToolReference Include="dotnet-fable" Version="1.0.4" />
   </ItemGroup>

--- a/src/Client/Messages.fs
+++ b/src/Client/Messages.fs
@@ -3,48 +3,13 @@ module Client.Messages
 open System
 open ServerCode.Domain
 
-/// The messages processed during login 
-type LoginMsg =
-  | GetTokenSuccess of string
-  | SetUserName of string
-  | SetPassword of string
-  | AuthError of exn
-  | ClickLogIn
-
-/// The different messages processed when interacting with the wish list
-type WishListMsg =
-  | LoadForUser of string
-  | FetchedWishList of WishList
-  | RemoveBook of Book
-  | AddBook
-  | TitleChanged of string
-  | AuthorsChanged of string
-  | LinkChanged of string
-  | FetchError of exn
-
 /// The different messages processed by the application
-type AppMsg = 
+type Msg = 
+  | MenuMsg of Client.Menu.Msg
   | LoggedIn
   | LoggedOut
+  | LogOut
   | StorageFailure of exn
   | OpenLogIn
-  | LoginMsg of LoginMsg
-  | WishListMsg of WishListMsg
-  | Logout
-
-/// The user data sent with every message.
-type UserData = 
-  { UserName : string 
-    Token : JWT }
-
-/// The different pages of the application. If you add a new page, then add an entry here.
-type Page = 
-  | Home 
-  | Login
-  | WishList
-
-let toHash =
-  function
-  | Home -> "#home"
-  | Login -> "#login"
-  | WishList -> "#wishlist"
+  | LoginMsg of Client.Login.Msg
+  | WishListMsg of Client.WishList.Msg

--- a/src/Client/Model.fs
+++ b/src/Client/Model.fs
@@ -1,0 +1,21 @@
+module Client.Model 
+
+open System
+open ServerCode.Domain
+
+/// The user data sent with every message.
+type UserData = 
+  { UserName : string 
+    Token : JWT }
+
+/// The different pages of the application. If you add a new page, then add an entry here.
+type Page = 
+  | Home 
+  | Login
+  | WishList
+
+let toHash =
+  function
+  | Home -> "#home"
+  | Login -> "#login"
+  | WishList -> "#wishlist"

--- a/src/Client/Style.fs
+++ b/src/Client/Style.fs
@@ -10,7 +10,7 @@ open Fable.Import.Browser
 open Fable.PowerPack
 open Elmish.Browser.Navigation
 open Elmish.Browser.UrlParser
-open Messages
+open Client.Model
 module R = Fable.Helpers.React
 
 

--- a/src/Client/components/Menu.fs
+++ b/src/Client/components/Menu.fs
@@ -10,16 +10,28 @@ open Elmish.Browser.UrlParser
 open Fable.Helpers.React
 open Fable.Helpers.React.Props
 open Client.Style
-open Client.Messages
 open System
+open Client.Model
 open Fable.Core.JsInterop
+
+// Messages.
+
+type Msg = 
+  | LogOut
+
+
+// Model.
 
 type Model = {
     User : UserData option
     query : string
 }
 
+// State.
+
 let init() = { User = Utils.load "user"; query = "" },Cmd.none
+
+// View
 
 let view (model:Model) dispatch =
     div [ centerStyle "row" ] [ 
@@ -29,5 +41,5 @@ let view (model:Model) dispatch =
           if model.User = None then 
               yield viewLink (Login) "Login" 
           else 
-              yield buttonLink "logout" (fun _ -> dispatch Logout) [ str "Logout" ]
+              yield buttonLink "logout" (fun _ -> dispatch LogOut) [ str "Logout" ]
         ]


### PR DESCRIPTION
I'm just getting up to speed on Elm and Elmish, via this scaffold and lots of great Elm examples on the internet.  I've found some parts of the code/structure of this base app very clear and others a little confusing.  Therefore, as part of my learning, I thought I would try and make some of this more obvious _to me_, and try and make it as clear as some of the very polished Elm examples.  I'm hoping I can use my newbie experience to help others that follow me.

Hopefully, some of the changes make sense and might benefit the code base.  Alternatively, I could be running before I can walk!  This PR is just a start.  Ultimately, the aim would be to contribute to creating a rock solid structure for a new SPA, along with docs clearly suggesting how to use it (with the usual Elm caveat of *do what's right for you man*!).  Anyway, I thought I'd raise a PR and see if it can start a discussion.  *If it's better done elsewhere, let me know*.

Changes are:  

Tried to improve the encapsulation of the child apps (i.e. pages and
menu component):

* Moved the child app message types into the child app files.  Think
this is an easier read for newbies and is similar to lot of Elm
examples.  [Example](https://github.com/bentayloruk/fable-suave-scaffold/blob/structure/src/Client/pages/WishList.fs).
* Commented the page files as per Kris Jenkins' [suggestion of Model,
Message, REST, State, View](http://blog.jenkster.com/2016/04/how-i-structure-elm-apps.html).
* Removed knowledge of App level message DU from child apps, by putting the
App level message DU in a file after the child apps in the fsproj
compilation order.  Made it the responsibility of the App to map child
message types to App message types (done with composing the dispatch
function and the child msg ctor).  *Done this under the assumption that
the child app should only know and communicate with its own messages.*

Other changes:

* Put Menu in a components folder, to reduce confusion about it being a
Page.  Seen this structure in other Elm apps.
* Put the 'global' model types in root Model.fs.  Not sure this is
quite right yet, for example, should a child component know about other
pages?  Anyway, OK for now.  Left the App specific model types in
App.fs.  This structure makesense in relation to the F# compilation order.
