### PR TITLE
server tests starter with live reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Start the development mode with:
 This command will call in **build.fsx** the target "Run". It will start in parallel:
 - **dotnet watch run** in [src/Server](src/Server/Server) (note: Suave is launched on port **8085**)
 - **dotnet fable webpack-dev-server** in [src/Client](src/Client) (note: the Webpack development server will serve files on http://localhost:8080)
+- **dotnet watch run** in [test/serverTests](src/ServerTests) to run unit tests
 
 Previously, the build script should download all dependencies like .NET Core SDK, Fable... If you have problems with the download of the .NET Core SDK via the `build.cmd` or `build.sh` script, please install the SDK manually from [here](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.0.4-download.md). Verify
 that you have at least SDK version 1.0.4 installed (`dotnet --version`) and then rerun the build script.

--- a/build.fsx
+++ b/build.fsx
@@ -100,6 +100,14 @@ Target "BuildServer" (fun _ ->
     runDotnet serverPath "build"
 )
 
+Target "InstallServerTests" (fun _ ->
+    runDotnet serverTestsPath "restore"
+)
+
+Target "BuildServerTests" (fun _ ->
+    runDotnet serverPath "build"
+)
+
 Target "InstallClient" (fun _ ->
     printfn "Node version:"
     run nodeTool "--version" __SOURCE_DIRECTORY__
@@ -135,7 +143,11 @@ Target "RenameDrivers" (fun _ ->
     | exn -> failwithf "Could not rename chromedriver at test/UITests/bin/Release/chromedriver. Message: %s" exn.Message
 )
 
-Target "RunTests" (fun _ ->
+Target "RunServerTests" (fun _ ->
+    runDotnet serverTestsPath "run"
+)
+
+Target "RunExecutableTests" (fun _ ->
     ActivateFinalTarget "KillProcess"
 
     let serverProcess =
@@ -273,12 +285,15 @@ Target "All" DoNothing
 "Clean"
   ==> "InstallDotNetCore"
   ==> "InstallServer"
+  ==> "InstallServerTests"
   ==> "InstallClient"
   ==> "BuildServer"
+  ==> "BuildServerTests"
+  ==> "RunServerTests"
   ==> "BuildClient"
   ==> "BuildTests"
   ==> "RenameDrivers"
-  ==> "RunTests"
+  ==> "RunExecutableTests"
   ==> "All"
   ==> "Publish"
   ==> "CreateDockerImage"

--- a/build.fsx
+++ b/build.fsx
@@ -25,6 +25,8 @@ let clientPath = "./src/Client" |> FullName
 
 let serverPath = "./src/Server/" |> FullName
 
+let serverTestsPath = "./test/ServerTests" |> FullName
+
 let dotnetcliVersion = "1.0.4"
 
 let mutable dotnetExePath = "dotnet"
@@ -173,13 +175,22 @@ Target "Run" (fun _ ->
                 info.WorkingDirectory <- serverPath
                 info.Arguments <- "watch run") TimeSpan.MaxValue
         if result <> 0 then failwith "Website shut down." }
-
+    
+    let unitTestsWatch = async {
+        let result = 
+            ExecProcess (fun info ->
+                info.FileName <- dotnetExePath
+                info.WorkingDirectory <- serverTestsPath
+                info.Arguments <- "watch run") TimeSpan.MaxValue
+            
+        if result <> 0 then failwith "Website shut down." }
+   
     let fablewatch = async { runDotnet clientPath "fable webpack-dev-server" }
     let openBrowser = async {
         System.Threading.Thread.Sleep(5000)
         Diagnostics.Process.Start("http://"+ ipAddress + sprintf ":%d" port) |> ignore }
 
-    Async.Parallel [| dotnetwatch; fablewatch; openBrowser |]
+    Async.Parallel [| dotnetwatch; unitTestsWatch; fablewatch; openBrowser |]
     |> Async.RunSynchronously
     |> ignore
 )

--- a/test/ServerTests/Program.fs
+++ b/test/ServerTests/Program.fs
@@ -1,0 +1,7 @@
+module ServerTests.TestsRunner
+
+open Expecto
+
+[<EntryPoint>]
+let main args =
+        runTestsWithArgs { defaultConfig with ``parallel`` = false } args ServerTests.Tests.wishListTests

--- a/test/ServerTests/ServerTests.fsproj
+++ b/test/ServerTests/ServerTests.fsproj
@@ -1,0 +1,19 @@
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
+    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+  </ItemGroup>
+  <Import Project="..\..\.paket\Paket.Restore.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Server\Server.fsproj" />
+  </ItemGroup>
+</Project>

--- a/test/ServerTests/ServerTests.fsproj
+++ b/test/ServerTests/ServerTests.fsproj
@@ -8,10 +8,6 @@
     <Compile Include="Program.fs" />
     <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="1.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\src\Server\Server.fsproj" />

--- a/test/ServerTests/Tests.fs
+++ b/test/ServerTests/Tests.fs
@@ -3,7 +3,6 @@ module ServerTests.Tests
 open Expecto
 open ServerCode
 
-[<Tests>]
 let wishListTests =
   testList "Wishlist" [
     testCase "default contains F# mastering book" <| fun _ ->

--- a/test/ServerTests/Tests.fs
+++ b/test/ServerTests/Tests.fs
@@ -1,0 +1,15 @@
+module ServerTests.Tests
+
+open Expecto
+open ServerCode
+
+[<Tests>]
+let wishListTests =
+  testList "Wishlist" [
+    testCase "default contains F# mastering book" <| fun _ ->
+      let defaults =  WishList.defaultWishList "test"
+      Expect.isNonEmpty defaults.Books "Default Books list should have at least one item"
+      Expect.isTrue
+        (defaults.Books |> Seq.exists (fun b -> b.Title = "Mastering F#")) 
+        "A good book should have been advertised"
+  ]

--- a/test/ServerTests/paket.references
+++ b/test/ServerTests/paket.references
@@ -1,3 +1,5 @@
+FSharp.NET.Sdk
+
 group Test
 FSharp.Core
 Expecto

--- a/test/ServerTests/paket.references
+++ b/test/ServerTests/paket.references
@@ -1,0 +1,3 @@
+group Test
+FSharp.Core
+Expecto


### PR DESCRIPTION
starter for #128 

what's working: live reload of test project and tests run.

I did not use Expecto Fake helpers, not sure if they would work with 'dotnet watch'

also I noticed at least once that 2 watching process deadlocked. Not sure what to do with it atm.

Signed-off-by: Alexander Prooks <aprooks@live.ru>