### PR TITLE
Ensure scaffold will still build with Suave 2.2.x

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -148,7 +148,7 @@ Target "RenameDrivers" (fun _ ->
     try
         if isMacOS && not <| File.Exists "test/UITests/bin/Debug/net461/chromedriver" then
             Fake.FileHelper.Rename "test/UITests/bin/Debug/net461/chromedriver" "test/UITests/bin/Debug/net461/chromedriver_macOS"
-        elif isLinux then
+        elif isLinux && not <| File.Exists "test/UITests/bin/Debug/net461/chromedriver" then
             Fake.FileHelper.Rename "test/UITests/bin/Debug/net461/chromedriver" "test/UITests/bin/Debug/net461/chromedriver_linux64"
     with
     | exn -> failwithf "Could not rename chromedriver at test/UITests/bin/Debug/net461/chromedriver. Message: %s" exn.Message

--- a/src/Server/Auth.fs
+++ b/src/Server/Auth.fs
@@ -4,10 +4,6 @@ module ServerCode.Auth
 open Suave
 open Suave.RequestErrors
 
-let unauthorized s = Suave.Response.response HTTP_401 s
-
-let UNAUTHORIZED s = unauthorized (UTF8.bytes s)
-
 /// Login web part that authenticates a user and returns a token in the HTTP body.
 let login (ctx: HttpContext) = async {
     let login = 


### PR DESCRIPTION
The UTF8.bytes function is hidden in Suave 2.2.0 and above, so we can't use it in the scaffold. Since the only functions that use it are exact duplicates of functions already in the Suave API, just remove them.

This will fix #145.